### PR TITLE
docs(templates): add GitHub Issue Templates and triage config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,64 @@
 name: Bug report
+description: Report a reproducible problem
+title: "[bug]: "
+labels: ["kind/bug", "prio/med"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `edgecrew.__version__` or the git SHA
+      placeholder: "v0.1.0"
+  - type: textarea
+    id: desc
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Clear steps, sample config, manifests or minimal code to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Output
+      description: Paste relevant logs (sanitize secrets); attach files if needed
+      render: shell
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - orchestrator
+        - agents
+        - models
+        - tools
+        - memory
+        - helm
+        - docs
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues
+          required: true
+        - label: I can reproduce this on the latest `main`
+          required: true
+
+name: Bug report
 description: Report a problem
 labels: [bug]
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Policy
+    url: ../SECURITY.md
+    about: Please report security issues privately following our security policy.
+  - name: Q&A / Discussions
+    url: ../README.md
+    about: Check the README first. For questions, open a discussion thread.
+
+defaults:
+  assignees: []
+  labels: []
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,44 @@
 name: Feature request
+description: Propose a new capability or enhancement
+title: "[feat]: "
+labels: ["kind/feature", "prio/med"]
+assignees: []
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Who benefits?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: High-level description; config examples; acceptance criteria
+      placeholder: |
+        - As a ...
+        - I want ...
+        - So that ...
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Considered alternatives and trade-offs
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - orchestrator
+        - agents
+        - models
+        - tools
+        - memory
+        - helm
+        - docs
+
+name: Feature request
 description: Propose an enhancement
 labels: [enhancement]
 body:

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,18 @@
+name: Maintenance / Chore
+description: Tooling, CI, docs, or non-functional improvements
+title: "[chore]: "
+labels: ["kind/chore"]
+assignees: []
+body:
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What part of the repo or tooling is affected?
+  - type: textarea
+    id: plan
+    attributes:
+      label: Plan
+      description: Steps to implement; expected impact and risks
+
+

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,55 @@
+name: RFC (design proposal)
+description: Request for Comments for a substantial design or architectural change
+title: "RFC: <title>"
+labels: ["kind/feature", "rfc", "prio/med"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for substantial changes that affect architecture, APIs, or workflows.
+        Keep it concise but technically rigorous.
+  - type: input
+    id: rfc-id
+    attributes:
+      label: RFC ID
+      description: Optional document or ADR/RFC number
+      placeholder: "RFC-000X"
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One- or two-paragraph high-level summary
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation & Goals
+      description: Why should we do this? What are the goals and non-goals?
+  - type: textarea
+    id: design
+    attributes:
+      label: Proposed Design
+      description: Architecture, interfaces, data flow, diagrams (if any)
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility / Migration
+      description: Breaking changes? Migration plan?
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation & Testing
+      description: How will we validate the change (unit/integration/e2e)? Success metrics?
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and Trade-offs
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to prior art, issues, docs
+
+


### PR DESCRIPTION
## Summary

<!-- What does this change? -->

## Type

- [ ] chore(hardening)
- [ ] fix
- [ ] feat
- [x ] docs

## Tests

- [ ] Unit tests added/updated
- [ ] CI green

## Notes
