### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tgarciai/edgecrew/security/code-scanning/2](https://github.com/tgarciai/edgecrew/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. The block can be added at the root level (to apply to all jobs) or at the job level (to apply to specific jobs). Since neither job appears to require write access (they only read code, install dependencies, and run tests), the minimal permission required is `contents: read`. This will restrict the GITHUB_TOKEN to only have read access to repository contents, following the principle of least privilege. The best way to implement this is to add the following block directly after the workflow `name` and before the `on:` key:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
